### PR TITLE
Present new work to the WG on DNSSEC automation

### DIFF
--- a/dnsop-ietf110/dnsop-ietf110-agenda-requests.md
+++ b/dnsop-ietf110/dnsop-ietf110-agenda-requests.md
@@ -16,3 +16,8 @@
     - Time Requested: 20 minutes
     - Chairs Action:
 
+*   Draft name: draft-wisser-dnssec-automation
+    - Datatracker URL: https://datatracker.ietf.org/doc/draft-wisser-dnssec-automation/
+    - Requester Email: ulrich.wisser@internetstiftelsen.se
+    - Time Requested: 10 min + questions
+    - Chairs Action:


### PR DESCRIPTION
Turns out changing DNS operators for a dnssec signed domain without going insecure is the same operation as multi-signer dnssec.
    We would like to present our work to the WG and ask for review and help with implementation.