### PR TITLE
Request agenda time for DNS Out of Protocol Signalling

### DIFF
--- a/dnsop-ietf117/dnsop-ietf117-agenda-requests.md
+++ b/dnsop-ietf117/dnsop-ietf117-agenda-requests.md
@@ -60,3 +60,10 @@
     - Time Requested: 15 min
     - DocType: For Consideration
 
+
+* Draft name: draft-grubto-dnsop-dns-out-of-protocol-signalling
+    - Datatracker URL: https://datatracker.ietf.org/doc/draft-grubto-dnsop-dns-out-of-protocol-signalling/
+    - Requester Email: Willem Toorop
+    - Time Requested: 15 min (I can do it in 10 minutes if needed)
+    - DocType: For Consideration
+


### PR DESCRIPTION
Sorry to be late, but quite a bit has happened surrounding this draft.

- We were notified that there is some overlap in our draft with the work that has been done at DOTS (but more lightweight). I think it would be good to notify the work group about that.
- The draft was the topic of one of the projects at the "Connect to Port 53" DNS Hackathon. I participated in it and we developed a lot of good insight that I'd like to share and discuss during the work group session.
- I'm planning to continue "hacking" on it during the IETF Hackathon.

I believe the work should continue in the work group.
I'll bring the draft in shape to be ready for adoption before submission deadline.
