### PR TITLE
Request 4 ID.axu-dnsop-catalog-zone-xfr-properties

### DIFF
--- a/dnsop-ietf126/dnsop-ietf126-agenda-requests.md
+++ b/dnsop-ietf126/dnsop-ietf126-agenda-requests.md
@@ -55,3 +55,9 @@
     - Requester Email: Wes Hardaker <wjhns1@hardakers.net>
     - Time Requested (including Q&A): 10-15 min
     - Chairs Action:
+
+*   Draft name: DNS Catalog Zone Properties for Zone Transfers
+    - Datatracker URL: https://datatracker.ietf.org/doc/draft-axu-dnsop-catalog-zone-xfr-properties/
+    - Requester Email: Willem Toorop <willem@nlnetlabs.nl>
+    - Time Requested (including Q&A): 10-15 min
+    - Chairs Action:


### PR DESCRIPTION
 @bjovereinder @oerdnj @peterthomassen 
Although the dnsop list stays quiet about this, I really do think it is relevant and operators (Nominet, RcodeZero, SIDN, TREX, InternetNZ etc.) are really using catalog zones, and looking out for these features. We also have at least vendor support from ISC (see latest Andrew Campling's weekly DNS episode when it becomes available). So... please?